### PR TITLE
fix(kustomize): disable pinDigests

### DIFF
--- a/dependencies/github-runners.json5
+++ b/dependencies/github-runners.json5
@@ -18,14 +18,5 @@
       separateMinorPatch: false,
       automerge: false,
     },
-    {
-      description: "github-runners: prevent pin of oci helmcharts",
-      matchDepNames: [
-        "gha-runner-scale-set",
-        "gha-runner-scale-set-controller",
-      ],
-      matchUpdateTypes: ["pin", "pinDigest"],
-      enabled: false,
-    },
   ],
 }

--- a/flux/default.json5
+++ b/flux/default.json5
@@ -8,7 +8,7 @@
   ],
   packageRules: [
     {
-      description: "flux: prevent pinDigests",
+      description: "flux: disable pinDigests",
       matchManagers: ["flux"],
       pinDigests: false,
     },

--- a/kustomize/default.json5
+++ b/kustomize/default.json5
@@ -2,4 +2,11 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   // https://docs.renovatebot.com/modules/manager/kustomize/
   extends: ["github>techtales-io/renovate-config//kustomize/automerge.json5"],
+  packageRules: [
+    {
+      description: "kustomize: disable pinDigests",
+      matchManagers: ["kustomize"],
+      pinDigests: false,
+    },
+  ],
 }


### PR DESCRIPTION
should fix

```
2025-04-28T19:10:19.9478120Z            "branchName": "renovate/pin-dependencies",
2025-04-28T19:10:19.9478509Z            "prNo": null,
2025-04-28T19:10:19.9478866Z            "prTitle": "chore(container): pin dependencies",
2025-04-28T19:10:19.9479269Z            "result": "error",
2025-04-28T19:10:19.9479588Z            "upgrades": [
2025-04-28T19:10:19.9479881Z              {
2025-04-28T19:10:19.9480166Z                "datasource": "docker",
2025-04-28T19:10:19.9480538Z                "depName": "flux-operator",
2025-04-28T19:10:19.9480914Z                "displayPending": "",
2025-04-28T19:10:19.9481274Z                "fixedVersion": "0.19.0",
2025-04-28T19:10:19.9481646Z                "currentVersion": "0.19.0",
2025-04-28T19:10:19.9482018Z                "currentValue": "0.19.0",
2025-04-28T19:10:19.9482378Z                "newValue": "0.19.0",
2025-04-28T19:10:19.9482914Z                "newDigest": "sha256:99c54be0f14d910b2269d41e4ac001e3649d816b3000066d2d33410b91420d9e",
2025-04-28T19:10:19.9483636Z                "packageFile": "kubernetes/kube-nas/bootstrap/flux-operator/kustomization.yaml",
2025-04-28T19:10:19.9484186Z                "updateType": "pinDigest",
2025-04-28T19:10:19.9484679Z                "packageName": "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"
2025-04-28T19:10:19.9485150Z              },
```